### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,24 +2,24 @@
 
 Link for all the notes shared till now : 
 
-- Dynamic Programming notes - https://github.com/riti2409/Dynamic-Programming-Notes 
+- Dynamic Programming notes - [Link](https://github.com/riti2409/Dynamic-Programming-Notes) 
 
-- OOPS notes - https://github.com/riti2409/OOPS_NOTES 
+- OOPS notes - [Link](https://github.com/riti2409/OOPS_NOTES )
 
-- DBMS/SQL notes - https://github.com/riti2409/DBMS_SQL-Notes 
+- DBMS/SQL notes - [Link](https://github.com/riti2409/DBMS_SQL-Notes )
 
-- Programming in C/C++ - https://github.com/riti2409/Programming_with_C_and_Cplus-plus 
+- Programming in C/C++ - [Link](https://github.com/riti2409/Programming_with_C_and_Cplus-plus )
 
-- Git/GitHub- https://github.com/riti2409/Git-GitHub 
+- Git/GitHub- [Link](https://github.com/riti2409/Git-GitHub )
 
-- HTML/CSS/JavaScript - https://github.com/riti2409/Resources_for_Web_Development 
+- HTML/CSS/JavaScript - [Link](https://github.com/riti2409/Resources_for_Web_Development )
 
-- Operating system - https://github.com/riti2409/Operating_System 
+- Operating system - [Link](https://github.com/riti2409/Operating_System )
 
-- DSA - https://github.com/riti2409/Complete_DSA
+- DSA - [Link](https://github.com/riti2409/Complete_DSA)
 
-- C++ STL - https://github.com/riti2409/Cplus-plus-STL 
+- C++ STL - [Link](https://github.com/riti2409/Cplus-plus-STL )
 
-- CN - https://www.linkedin.com/feed/update/urn:li:activity:6904693012644147201/
+- CN - [Link](https://www.linkedin.com/feed/update/urn:li:activity:6904693012644147201/)
 
-** Resources for preparation of placements-https://lnkd.in/d6zpHj4P **
+** Resources for preparation of placements-[Link](https://lnkd.in/d6zpHj4P) **


### PR DESCRIPTION
So, this is what is happening, whenever you try to open the link it appends - "%E2%80%A8" at the end of the URL.  This is encoded character representation for line-separator in Unicode-8. So if we replace it with current syntax it will be easy to navigate to the destination. Thank You